### PR TITLE
bug: Fixing return issue

### DIFF
--- a/benchmarks/tuple_return_bench.stl
+++ b/benchmarks/tuple_return_bench.stl
@@ -76,9 +76,9 @@ let test2 = fn() {
 };
 let a2, b2, c2 = test2();
 println("Test 2 - Two levels of nesting:");
-println(a2);  // Should be 7
-println(b2);  // Should be 6
-println(c2);  // Should be 5
+println(a2);
+println(b2);
+println(c2);
 
 // Three levels of nesting
 let test3 = fn() {
@@ -92,9 +92,9 @@ let test3 = fn() {
 };
 let a3, b3, c3 = test3();
 println("Test 3 - Three levels of nesting:");
-println(a3);  // Should be 7
-println(b3);  // Should be 5
-println(c3);  // Should be 3
+println(a3);
+println(b3);
+println(c3);
 
 // Multiple nested calls in one expression
 let test4 = fn() {
@@ -141,9 +141,9 @@ let test6 = fn() {
 };
 let a6, b6, c6 = test6();
 println("Test 6 - Deep nesting with computation:");
-println(a6);  // Should be 42 ((3 + 3) * 2 + 30)
-println(b6);  // Should be 28 ((2 + 2) * 2 + 20)
-println(c6);  // Should be 14 ((1 + 1) * 2 + 10)
+println(a6);
+println(b6);
+println(c6);
 
 // Test with mixed return counts at different nesting levels
 let test7 = fn() {
@@ -161,6 +161,6 @@ let test7 = fn() {
 };
 let a7, b7 = test7();
 println("Test 7 - Mixed return counts:");
-println(a7);  // Should be 9 (6 + 3)
-println(b7);  // Should be 3 (1 + 2)
+println(a7);
+println(b7);
 

--- a/chunk.h
+++ b/chunk.h
@@ -66,7 +66,6 @@ typedef enum {
 	OP_TABLE,
 	OP_ANON_FUNCTION,
 	OP_UNPACK_TUPLE,
-	OP_RETURN_MULTI,
 } OpCode;
 
 typedef struct {

--- a/compiler.c
+++ b/compiler.c
@@ -99,7 +99,7 @@ static void emitReturn() {
 	} else {
 		emitByte(OP_NIL);
 	}
-	emitByte(OP_RETURN);
+	emitBytes(OP_RETURN, 0);
 }
 
 static uint8_t makeConstant(Value value) {
@@ -883,11 +883,7 @@ static void returnStatement() {
 		} while (match(TOKEN_COMMA));
 
 		consume(TOKEN_SEMICOLON, "Expected ';' after return value");
-		if (valueCount == 1) {
-			emitByte(OP_RETURN);
-		} else {
-			emitBytes(OP_RETURN_MULTI, valueCount);
-		}
+		emitBytes(OP_RETURN, valueCount);
 	}
 }
 

--- a/compiler.c
+++ b/compiler.c
@@ -763,6 +763,7 @@ static void varDeclaration() {
 		}
 
 		emitBytes(OP_UNPACK_TUPLE, variableCount);
+		emitByte(current->scopeDepth);
 
 		for (uint8_t i = 0; i < variableCount; i++) {
 			defineVariable(variables[i]);

--- a/debug.c
+++ b/debug.c
@@ -206,9 +206,6 @@ int disassembleInstruction(Chunk *chunk, int offset) {
 		case OP_UNPACK_TUPLE: {
 			return byteInstruction("OP_UNPACK_TUPLE", chunk, offset);
 		}
-		case OP_RETURN_MULTI: {
-			return simpleInstruction("OP_RETURN_MULTI", offset);
-		}
 		case OP_ANON_FUNCTION: {
 			return constantInstruction("OP_ANON_FUNCTION", chunk, offset);
 		}


### PR DESCRIPTION
- return values are now returned in the order in which they are typed.
- multiple assignment now assigns values in the order in which they are written.
- Removed the `OP_RETURN_MULTI` instruction. `OP_RETURN` now handles returns of both single and multiple values.
