### PR TITLE
feat: tagged object pointers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ option(CRUX_DEBUG_TRACE_EXECUTION "Enable execution tracing" OFF)
 option(CRUX_DEBUG_PRINT_CODE "Print compiled bytecode" OFF)
 option(CRUX_DEBUG_LOG_GC "Enable GC logging" OFF)
 option(CRUX_DEBUG_STRESS_GC "Enable GC stress mode" OFF)
+option(CRUX_TAGGED_OBJECT "Enables tagged pointers for objects. Should not be used on 32 bit platforms." ON)
 set(CRUX_VERSION "dev" CACHE STRING "Crux language version")
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -85,6 +86,7 @@ target_compile_definitions(crux PRIVATE
         $<$<BOOL:${CRUX_DEBUG_PRINT_CODE}>:DEBUG_PRINT_CODE>
         $<$<BOOL:${CRUX_DEBUG_LOG_GC}>:DEBUG_LOG_GC>
         $<$<BOOL:${CRUX_DEBUG_STRESS_GC}>:DEBUG_STRESS_GC>
+        $<$<BOOL:${CRUX_TAGGED_OBJECT}>:CRUX_TAGGED_OBJECT>
         CRUX_VERSION="${CRUX_VERSION}"
 )
 
@@ -121,7 +123,10 @@ endif()
 if(CRUX_DEBUG_STRESS_GC)
   message(STATUS "    - CRUX_DEBUG_STRESS_GC: ON")
 endif()
-if(NOT CRUX_STACK_SAFETY AND NOT CRUX_DEBUG_TRACE_EXECUTION AND NOT CRUX_DEBUG_PRINT_CODE AND NOT CRUX_DEBUG_LOG_GC AND NOT CRUX_DEBUG_STRESS_GC)
+if(CRUX_TAGGED_OBJECT)
+  message(STATUS "    - CRUX_TAGGED_OBJECT: ON")
+endif()
+if(NOT CRUX_STACK_SAFETY AND NOT CRUX_DEBUG_TRACE_EXECUTION AND NOT CRUX_DEBUG_PRINT_CODE AND NOT CRUX_DEBUG_LOG_GC AND NOT CRUX_DEBUG_STRESS_GC AND NOT CRUX_TAGGED_OBJECT)
   message(STATUS "    (none)")
 endif()
 message(STATUS "")

--- a/include/garbage_collector.h
+++ b/include/garbage_collector.h
@@ -93,7 +93,7 @@ void mark_object_internal(VM* vm, CruxObject* object);
  */
 static inline void mark_object(VM *vm, CruxObject *object)
 {
-	if (object == NULL || object->is_marked || object->is_immortal)
+	if (object == NULL || object_is_marked(object) || object_is_immortal(object))
 		return;
 
 	mark_object_internal(vm, object);

--- a/include/object.h
+++ b/include/object.h
@@ -1,8 +1,10 @@
 #ifndef OBJECT_H
 #define OBJECT_H
 
+#include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <sys/types.h>
 
 #include "chunk.h"
 #include "table.h"
@@ -36,8 +38,7 @@
 		OBJECT_VAL(gcSafeResult);                                                                                      \
 	})
 
-#define OBJECT_TYPE(value) (AS_CRUX_OBJECT(value)->type)
-#define OBJECT_SET_TYPE(obj, obj_type) ((obj)->type = (obj_type))
+#define OBJECT_TYPE(value) (object_get_type(AS_CRUX_OBJECT(value)))
 
 #define IS_CRUX_STRING(value) is_object_type(value, OBJECT_STRING)
 #define IS_CRUX_FUNCTION(value) is_object_type(value, OBJECT_FUNCTION)
@@ -131,23 +132,118 @@ typedef enum {
 	OBJECT_OPTION,
 	OBJECT_ENUM,
 	OBJECT_COROUTINE,
+	SENTINEL_OBJECT_COUNT
 } ObjectType;
 
+static_assert(SENTINEL_OBJECT_COUNT <= 32, "Object type count exceeds 32 bits");
+
+#ifdef CRUX_TAGGED_OBJECT
+
+#ifdef __i386__
+#error "Tagged objects are not supported on 32-bit architectures. Please compile with -DCRUX_TAGGED_OBJECT=OFF"
+#endif
+
+#if UINTPTR_MAX == 0xFFFFFFFF
+#error "Tagged objects are not supported on 32-bit architectures. Please compile with -DCRUX_TAGGED_OBJECT=OFF"
+#endif
+
+struct CruxObject {
+    uintptr_t tagged_next;
+};
+
+#define CRUX_TAGGED_POINTER_MASK 0x0000FFFFFFFFFFFFULL
+#define CRUX_TAGGED_TAG_MASK 0xFFFF000000000000ULL
+
+#define CRUX_TAGGED_TYPE_SHIFT 48
+#define CRUX_TAGGED_TYPE_MASK 0x1FULL
+
+#define CRUX_TAGGED_MARKED_SHIFT 53
+#define CRUX_TAGGED_IMMORTAL_SHIFT 54
+
+#else
 struct CruxObject { // 16
     CruxObject* next;
 	ObjectType type;
 	bool is_marked;
 	bool is_immortal;
-	bool use_for_some_other_flag_in_the_future;
 };
+#endif
 
-#define MARK_BIT ((uintptr_t)1 << 63)
-#define PTR_MASK (~MARK_BIT)
-#define IS_MARKED(obj) ((uintptr_t)(obj)->data & MARK_BIT)
-#define GET_DATA(obj) ((void *)((uintptr_t)(obj)->data & PTR_MASK))
-#define SET_DATA(obj, ptr) ((obj)->data = (void *)((uintptr_t)(ptr) | ((uintptr_t)(obj)->data & MARK_BIT)))
-#define SET_MARKED(obj, marked)                                                                                        \
-	((obj)->data = (void *)(((uintptr_t)(obj)->data & PTR_MASK) | ((marked) ? MARK_BIT : 0)))
+// Object getters
+
+static inline CruxObject* object_get_next(CruxObject* object) {
+    #ifdef CRUX_TAGGED_OBJECT
+    return (CruxObject*)(object->tagged_next & CRUX_TAGGED_POINTER_MASK);
+    #else
+    return object->next;
+    #endif
+}
+
+static inline ObjectType object_get_type(CruxObject* object) {
+    #ifdef CRUX_TAGGED_OBJECT
+    return (ObjectType)((object->tagged_next >> CRUX_TAGGED_TYPE_SHIFT) & CRUX_TAGGED_TYPE_MASK);
+    #else
+    return object->type;
+    #endif
+}
+
+static inline bool object_is_marked(CruxObject* object) {
+    #ifdef CRUX_TAGGED_OBJECT
+    return (object->tagged_next >> CRUX_TAGGED_MARKED_SHIFT) & 1;
+    #else
+    return object->is_marked;
+    #endif
+}
+
+static inline bool object_is_immortal(CruxObject* object) {
+    #ifdef CRUX_TAGGED_OBJECT
+    return (object->tagged_next >> CRUX_TAGGED_IMMORTAL_SHIFT) & 1;
+    #else
+    return object->is_immortal;
+    #endif
+}
+
+
+static inline void object_set_next(CruxObject* object, CruxObject* next) {
+    #ifdef CRUX_TAGGED_OBJECT
+    object->tagged_next = (object->tagged_next & ~CRUX_TAGGED_POINTER_MASK) | ((uintptr_t)next & CRUX_TAGGED_POINTER_MASK);
+    #else
+    object->next = next;
+    #endif
+}
+
+static inline void object_set_marked(CruxObject* object, bool marked) {
+    #ifdef CRUX_TAGGED_OBJECT
+    object->tagged_next = (object->tagged_next & ~(1ULL << CRUX_TAGGED_MARKED_SHIFT)) | ((uintptr_t)marked << CRUX_TAGGED_MARKED_SHIFT);
+    #else
+    object->is_marked = marked;
+    #endif
+}
+
+static inline void object_set_immortal(CruxObject* object, bool immortal) {
+    #ifdef CRUX_TAGGED_OBJECT
+    object->tagged_next = (object->tagged_next & ~(1ULL << CRUX_TAGGED_IMMORTAL_SHIFT)) | ((uintptr_t)immortal << CRUX_TAGGED_IMMORTAL_SHIFT);
+    #else
+    object->is_immortal = immortal;
+    #endif
+}
+
+static inline void object_init(CruxObject* object, CruxObject* next,  ObjectType type, bool marked, bool immortal) {
+    #ifdef CRUX_TAGGED_OBJECT
+    uintptr_t tags = 0;
+    tags |= ((uintptr_t) type & CRUX_TAGGED_TYPE_MASK) << CRUX_TAGGED_TYPE_SHIFT;
+    tags |= ((uintptr_t) marked) << CRUX_TAGGED_MARKED_SHIFT;
+    tags |= ((uintptr_t) immortal) << CRUX_TAGGED_IMMORTAL_SHIFT;
+
+    object->tagged_next = ((uintptr_t) next & CRUX_TAGGED_POINTER_MASK) | tags;
+    #else
+    object->next = next;
+    object->type = type;
+    object->is_marked = marked;
+    object->is_immortal = immortal;
+    #endif
+}
+
 
 #define TO_DOUBLE(value) (IS_INT((value)) ? (double)AS_INT((value)) : AS_FLOAT((value)))
 
@@ -466,7 +562,7 @@ typedef struct { // 20
 
 static bool is_object_type(const Value value, const ObjectType type)
 {
-	return IS_CRUX_OBJECT(value) && AS_CRUX_OBJECT(value)->type == type;
+	return IS_CRUX_OBJECT(value) && object_get_type(AS_CRUX_OBJECT(value)) == type;
 }
 
 ObjectError *new_error(VM *vm, ObjectString *message, ErrorType type, bool is_panic);

--- a/include/object.h
+++ b/include/object.h
@@ -161,7 +161,7 @@ struct CruxObject {
 #define CRUX_TAGGED_IMMORTAL_SHIFT 54
 
 #else
-struct CruxObject { // 16
+struct CruxObject {
     CruxObject* next;
 	ObjectType type;
 	bool is_marked;
@@ -247,7 +247,7 @@ static inline void object_init(CruxObject* object, CruxObject* next,  ObjectType
 
 #define TO_DOUBLE(value) (IS_INT((value)) ? (double)AS_INT((value)) : AS_FLOAT((value)))
 
-struct ObjectString { // 24
+struct ObjectString {
 	CruxObject object;
 	utf8_int8_t* chars;
 	uint32_t byte_length; // this is the length without the null terminator
@@ -257,7 +257,7 @@ struct ObjectString { // 24
 
 typedef struct ObjectModuleRecord ObjectModuleRecord;
 
-typedef struct { // 72
+typedef struct {
 	CruxObject object;
 	int arity;
 	int upvalue_count;
@@ -266,28 +266,28 @@ typedef struct { // 72
 	ObjectModuleRecord *module_record;
 } ObjectFunction;
 
-typedef struct ObjectUpvalue { // 32
+typedef struct ObjectUpvalue {
 	CruxObject object;
 	Value *location;
 	Value closed;
 	ObjectUpvalue *next;
 } ObjectUpvalue;
 
-typedef struct ObjectClosure { // 32
+typedef struct ObjectClosure {
 	CruxObject object;
 	ObjectFunction *function;
 	ObjectUpvalue **upvalues;
 	int upvalue_count;
 } ObjectClosure;
 
-typedef struct { // 24
+typedef struct {
 	CruxObject object;
 	Value *values;
 	uint32_t size;
 	uint32_t capacity;
 } ObjectArray;
 
-typedef struct { // 16
+typedef struct {
 	CruxObject object;
 	uint64_t seed;
 } ObjectRandom;
@@ -320,14 +320,14 @@ typedef enum {
 	IMPORT,
 } ErrorType;
 
-typedef struct { // 24
+typedef struct {
 	CruxObject object;
 	ObjectString *message;
 	ErrorType type;
 	bool is_panic;
 } ObjectError;
 
-struct ObjectResult { // 24
+struct ObjectResult {
 	CruxObject object;
 	bool is_ok;
 	union {
@@ -336,28 +336,19 @@ struct ObjectResult { // 24
 	} as;
 };
 
-typedef struct { // 24
+typedef struct {
 	CruxObject object;
 	Value value;
 	bool is_some;
 } ObjectOption;
 
-typedef struct { // 32
+typedef struct {
 	CruxObject object;
 	ObjectString *name;
 	Table fields;
 	Table methods;
 } ObjectStruct;
 
-// Not implemented yet
-typedef struct { // 24
-	CruxObject object;
-} ObjectEnum;
-
-// Not implemented yet
-typedef struct { // 24
-	CruxObject object;
-} ObjectCoroutine;
 
 typedef struct ObjectTypeTable ObjectTypeTable;
 
@@ -366,14 +357,14 @@ typedef struct {
 	ObjectTypeRecord *value;
 } TypeEntry;
 
-struct ObjectTypeTable { // 24
+struct ObjectTypeTable {
 	CruxObject object;
 	TypeEntry *entries;
 	int count;
 	int capacity;
 };
 
-struct ObjectTypeRecord { // 40
+struct ObjectTypeRecord {
 	CruxObject object;
 	TypeMask base_type;
 	union {
@@ -432,7 +423,7 @@ struct ObjectTypeRecord { // 40
 
 typedef Value (*CruxCallable)(VM *vm, const Value *args);
 
-typedef struct { // 48
+typedef struct {
 	CruxObject object;
 	CruxCallable function;
 	ObjectString *name;
@@ -441,20 +432,20 @@ typedef struct { // 48
 	ObjectTypeRecord *return_type;
 } ObjectNativeCallable;
 
-typedef struct { // 24
+typedef struct {
 	Value key;
 	Value value;
 	bool is_occupied;
 } ObjectTableEntry;
 
-typedef struct { // 24
+typedef struct {
 	CruxObject object;
 	ObjectTableEntry *entries;
 	uint32_t capacity;
 	uint32_t size;
 } ObjectTable;
 
-typedef struct { // 48
+typedef struct {
 	CruxObject object;
 	ObjectString *path;
 	ObjectString *mode;
@@ -463,7 +454,7 @@ typedef struct { // 48
 	bool is_open;
 } ObjectFile;
 
-struct ObjectStructInstance { // 32
+struct ObjectStructInstance {
 	CruxObject object;
 	ObjectStruct *struct_type;
 	Value *fields;
@@ -474,7 +465,7 @@ struct ObjectStructInstance { // 32
 #define VECTOR_COMPONENTS(vec)                                                                                         \
 	((vec)->dimensions <= STATIC_VECTOR_SIZE ? (vec)->as.s_components : (vec)->as.h_components)
 
-typedef struct { // 48
+typedef struct {
 	CruxObject object;
 	uint32_t dimensions;
 	union {
@@ -483,8 +474,7 @@ typedef struct { // 48
 	} as;
 } ObjectVector;
 
-typedef struct // 32
-{
+typedef struct {
 	CruxObject object;
 	double real;
 	double imag;
@@ -511,7 +501,7 @@ struct ObjectIterator {
 	uint32_t index;
 };
 
-struct ObjectModuleRecord { // 120
+struct ObjectModuleRecord {
 	CruxObject object;
 	VM* owner;
 	ObjectString *path;
@@ -534,19 +524,19 @@ struct ObjectModuleRecord { // 120
 	bool is_main;
 };
 
-struct ObjectRange { // 40
+struct ObjectRange {
 	CruxObject object;
 	int32_t start;
 	int32_t end;
 	int32_t step;
 };
 
-typedef struct { // 24
+typedef struct {
 	CruxObject object;
 	ObjectTable *entries;
 } ObjectSet;
 
-typedef struct { // 32
+typedef struct {
 	CruxObject object;
 	uint32_t read_pos;
 	uint32_t write_pos;
@@ -554,7 +544,7 @@ typedef struct { // 32
 	uint8_t *data;
 } ObjectBuffer;
 
-typedef struct { // 20
+typedef struct {
 	CruxObject object;
 	uint32_t size;
 	Value *elements;

--- a/src/memory/garbage_collector.c
+++ b/src/memory/garbage_collector.c
@@ -85,7 +85,7 @@ static size_t compute_next_gc_threshold(const VM *vm)
 
 void mark_object_internal(VM *vm, CruxObject *object)
 {
-	object->is_marked = true;
+	object_set_marked(object, true);
 
 	if (vm->gray_capacity < vm->gray_count + 1) {
 		vm->gray_capacity = GROW_CAPACITY(vm->gray_capacity);
@@ -241,7 +241,7 @@ static void blacken_object(VM *vm, CruxObject *object)
 	printf("\n");
 #endif
 
-	const ObjectType type = object->type;
+	const ObjectType type = object_get_type(object);
 	if (type < (ObjectType)(sizeof(blacken_dispatch) / sizeof(blacken_dispatch[0]))) {
 		blacken_dispatch[type](vm, object);
 	}
@@ -814,35 +814,41 @@ static void trace_references(VM *vm)
 static void free_object(VM *vm, CruxObject *object, bool free_all)
 {
 #ifdef DEBUG_LOG_GC
-	printf("%p free type %d\n", (void *)object, object->type);
+	printf("%p free type %d\n", (void *)object, object_get_type(object));
 #endif
-	if (object == NULL || (object->is_immortal && !free_all))
+	if (object == NULL || (object_is_immortal(object) && !free_all))
 		return;
 
-	if (object->type < (ObjectType)(sizeof(free_dispatch) / sizeof(free_dispatch[0]))) {
-		free_dispatch[object->type](vm, object);
+	if (object_get_type(object) < (ObjectType)(sizeof(free_dispatch) / sizeof(free_dispatch[0]))) {
+		free_dispatch[object_get_type(object)](vm, object);
 	}
 }
 
 static void sweep(VM *vm)
 {
-	CruxObject **object = &vm->objects;
 	size_t slots_scanned = 0;
+	CruxObject *prev = NULL;
+	CruxObject *current = vm->objects;
 
-	while (*object != NULL) {
+	while (current != NULL) {
 		slots_scanned++;
-		if (!(*object)->is_marked) {
-			// Unlink dead object
-			CruxObject *unreached = *object;
-			*object = unreached->next;
+		CruxObject *next = object_get_next(current);
 
-			free_object(vm, unreached, false);
+		if (!object_is_marked(current)) {
+			// Unlink dead object
+			if (prev == NULL)
+				vm->objects = next;
+			else
+				object_set_next(prev, next);
+
+			free_object(vm, current, false);
 			vm->object_count--;
 		} else {
-			// Unmark and move to next
-			(*object)->is_marked = false;
-			object = &(*object)->next;
+			// Unmark and advance
+			object_set_marked(current, false);
+			prev = current;
 		}
+		current = next;
 	}
 
 	vm->gc_last_sweep_slots_scanned = slots_scanned;
@@ -856,7 +862,7 @@ void free_objects(VM *vm, bool free_all)
 {
 	CruxObject *object = vm->objects;
 	while (object != NULL) {
-		CruxObject *next = object->next;
+		CruxObject *next = object_get_next(object);
 		free_object(vm, object, free_all);
 		object = next;
 	}

--- a/src/object.c
+++ b/src/object.c
@@ -32,15 +32,9 @@
 CruxObject *allocate_pooled_object(VM *vm, const size_t size, const ObjectType type)
 {
 	CruxObject *object = allocate_object_with_gc(vm, size);
-
-	object->type = type;
-	object->is_marked = false;
-	object->is_immortal = false;
-
-	// Insert at head of global object list
-	object->next = vm->objects;
-	vm->objects = object;
+	object_init(object, vm->objects, type, false, false);
 	vm->object_count++;
+	vm->objects = object;
 
 #ifdef DEBUG_LOG_GC
 	printf("%p allocate %zu for %d\n", (void *)object, size, type);
@@ -701,6 +695,9 @@ void print_object_to(FILE *stream, const Value value, const bool in_collection)
 		fprintf(stream, "<Coroutine>");
 		break;
 	}
+	case SENTINEL_OBJECT_COUNT:
+		fprintf(stream, "<SENTINEL_OBJECT_COUNT>");
+		break;
 	}
 }
 

--- a/src/stdlib/stdlib.c
+++ b/src/stdlib/stdlib.c
@@ -151,20 +151,20 @@ bool register_native_method(VM *vm, Table *method_table, const char *method_name
 			FREE_ARRAY(vm, ObjectTypeRecord *, arg_types, arity);
 		return false;
 	}
-	name->object.is_immortal = true; // method names are immortal
+	object_set_immortal(&name->object, true); // method names are immortal
 	ObjectNativeCallable *callable = new_native_callable(vm, method_function, arity, name, arg_types, return_type);
 	if (!callable) {
 		if (arg_types && arity > 0)
 			FREE_ARRAY(vm, ObjectTypeRecord *, arg_types, arity);
 		return false;
 	}
-	callable->object.is_immortal = true; // method callables are immortal
+	object_set_immortal(&callable->object, true); // method callables are immortal
 
 	for (int i = 0; i < arity; i++) {
 		ObjectTypeRecord *arg_type = arg_types[i];
-		arg_type->object.is_immortal = true; // argument types are immortal
+		object_set_immortal(&arg_type->object, true); // argument types are immortal
 	}
-	return_type->object.is_immortal = true; // return type is immortal
+	object_set_immortal(&return_type->object, true); // return type is immortal
 
 	table_set(vm, method_table, name, OBJECT_VAL(callable));
 	return true;
@@ -181,7 +181,7 @@ static bool register_native_function(VM *vm, Table *function_table, const char *
 			FREE_ARRAY(vm, ObjectTypeRecord *, arg_types, arity);
 		return false;
 	}
-	name->object.is_immortal = true; // function names are immortal
+	object_set_immortal(&name->object, true); // function names are immortal
 	push(module_record, OBJECT_VAL(name));
 	ObjectNativeCallable *callable = new_native_callable(vm, function, arity, name, arg_types, return_type);
 	if (!callable) {
@@ -189,13 +189,13 @@ static bool register_native_function(VM *vm, Table *function_table, const char *
 			FREE_ARRAY(vm, ObjectTypeRecord *, arg_types, arity);
 		return false;
 	}
-	callable->object.is_immortal = true; // function callables are immortal
+	object_set_immortal(&callable->object, true); // function callables are immortal
 
 	for (int i = 0; i < arity; i++) {
 		ObjectTypeRecord *arg_type = arg_types[i];
-		arg_type->object.is_immortal = true; // argument types are immortal
+		object_set_immortal(&arg_type->object, true); // argument types are immortal
 	}
-	return_type->object.is_immortal = true; // return type is immortal
+	object_set_immortal(&return_type->object, true); // return type is immortal
 
 	const Value func = OBJECT_VAL(callable);
 	push(module_record, func);
@@ -243,7 +243,7 @@ static bool init_module(VM *vm, const char *module_name, const Callable *functio
 	}
 
 	ObjectString *name_copy = copy_string(vm, module_name, (int)strlen(module_name));
-	name_copy->object.is_immortal = true; // module names are immortal
+	object_set_immortal(&name_copy->object, true); // module names are immortal
 	vm->native_modules.modules[vm->native_modules.count++] = (NativeModule){.name = name_copy, .names = module_table};
 	return true;
 }

--- a/src/table.c
+++ b/src/table.c
@@ -171,7 +171,7 @@ void table_remove_white(const VM *vm, const Table *table)
 		if (entry->key == NULL)
 			continue;
 
-		if (!entry->key->object.is_marked) {
+		if (!object_is_marked(&entry->key->object)) {
 			table_delete(table, entry->key);
 		}
 	}

--- a/src/vm/vm_run.c
+++ b/src/vm/vm_run.c
@@ -562,7 +562,7 @@ OP_GET_COLLECTION: {
 		runtime_panic(current_module_record, TYPE, "Cannot get from a non-collection type.");
 		return INTERPRET_RUNTIME_ERROR;
 	}
-	switch (AS_CRUX_OBJECT(PEEK(current_module_record, 0))->type) {
+	switch (object_get_type(AS_CRUX_OBJECT(PEEK(current_module_record, 0)))) {
 	case OBJECT_TABLE: {
 		if (IS_CRUX_HASHABLE(indexValue)) {
 			ObjectTable *table = AS_CRUX_TABLE(PEEK(current_module_record, 0));
@@ -665,7 +665,7 @@ OP_SET_COLLECTION: {
 	Value indexValue = PEEK(current_module_record, 0);
 	Value collection = PEEK(current_module_record, 1);
 
-	switch (AS_CRUX_OBJECT(collection)->type) {
+	switch (object_get_type(AS_CRUX_OBJECT(collection))) {
 	case OBJECT_TABLE: {
 		ObjectTable *table = AS_CRUX_TABLE(collection);
 		if (IS_INT(indexValue) || IS_CRUX_STRING(indexValue)) {
@@ -1504,7 +1504,7 @@ OP_GET_SLICE: {
 		runtime_panic(current_module_record, TYPE, "Cannot get from a non-collection type.");
 		return INTERPRET_RUNTIME_ERROR;
 	}
-	switch (AS_CRUX_OBJECT(PEEK(current_module_record, 0))->type) {
+	switch (object_get_type(AS_CRUX_OBJECT(PEEK(current_module_record, 0)))) {
 	case OBJECT_ARRAY: {
 		ObjectArray *array = AS_CRUX_ARRAY(PEEK(current_module_record, 0));
 		uint32_t len = range_len(range);
@@ -1617,7 +1617,7 @@ OP_IN: {
 	Value right = pop(current_module_record);
 	Value left = pop(current_module_record);
 
-	ObjectType right_type = AS_CRUX_OBJECT(right)->type;
+	ObjectType right_type = object_get_type(AS_CRUX_OBJECT(right));
 
 	if (IS_CRUX_OBJECT(right)) {
 		switch (right_type) {


### PR DESCRIPTION
- tagged object pointers can be disabled with a build flag, but are enabled by default.
- tagged object pointers do not work on 32 bit machines. If compiling with 32 bit systems set `-DCRUX_TAGGED_OBJECTS=OFF` to use the non tagged object implementation
- 55s -> 49s execution time on ray tracer 